### PR TITLE
Fix gaps parameters for matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ osrm-backend: data/new-york-latest.osrm.core
 		osrm-routed /data/new-york-latest.osrm
 
 test:
-	python setup.py test
+	python3 setup.py test
 
 lint:
 	flake8 --ignore=F403,E501,E241,C812 osrm.py

--- a/osrm.py
+++ b/osrm.py
@@ -1,5 +1,5 @@
 import asyncio
-import collections
+import collections.abc
 import enum
 import logging
 import numbers
@@ -73,8 +73,8 @@ class OSRMClientException(OSRMException):
 def _check_pairs(items):
     ''' checking that 'items' has format [[Number, Number], ...]'''
     return (
-        isinstance(items, collections.Iterable) and
-        all([isinstance(p, collections.Iterable) for p in items]) and
+        isinstance(items, collections.abc.Iterable) and
+        all([isinstance(p, collections.abc.Iterable) for p in items]) and
         all([
             isinstance(p[0], numbers.Number) and
             isinstance(p[1], numbers.Number) and

--- a/osrm.py
+++ b/osrm.py
@@ -208,7 +208,7 @@ class MatchRequest(RouteRequest):
         options['timestamps'] = self._encode_array(self.timestamps)
 
         # Don't send default values (for compatibility with 5.6)
-        if self.gaps.value == osrm_gaps.split:
+        if self.gaps.value != osrm_gaps.split:
             options['gaps'] = self.gaps.value
         if self.tidy:
             options['tidy'] = self._encode_bool(self.tidy)

--- a/osrm.py
+++ b/osrm.py
@@ -58,6 +58,16 @@ class gaps(enum.Enum):
 osrm_gaps = gaps
 
 
+class continue_straight(enum.Enum):
+    default = 'default'
+    true = 'true'
+    false = 'false'
+
+
+# alias for avoiding name collision
+osrm_continue_straight = continue_straight
+
+
 class OSRMException(Exception):
     pass
 
@@ -156,7 +166,9 @@ class RouteRequest(BaseRequest):
             alternatives=False,
             steps=False, annotations=False,
             geometries=geometries.geojson,
-            overview=overview.simplified, **kwargs):
+            overview=overview.simplified,
+            continue_straight=continue_straight.default,
+            **kwargs):
         super().__init__(**kwargs)
 
         assert isinstance(alternatives, bool)
@@ -164,12 +176,14 @@ class RouteRequest(BaseRequest):
         assert isinstance(annotations, bool)
         assert isinstance(geometries, osrm_geometries)
         assert isinstance(overview, osrm_overview)
+        assert isinstance(continue_straight, osrm_continue_straight)
 
         self.alternatives = alternatives
         self.steps = steps
         self.annotations = annotations
         self.geometries = geometries
         self.overview = overview
+        self.continue_straight = continue_straight
 
     def get_options(self):
         options = super().get_options()
@@ -180,6 +194,8 @@ class RouteRequest(BaseRequest):
             'geometries':   self.geometries.value,
             'overview':     self.overview.value
         })
+        if self.continue_straight != continue_straight.default:
+            options['continue_straight'] = self.continue_straight.value
         return options
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='osrm-py',
-    version='0.4',
+    version='0.5',
     author='Alexander Verbitsky',
     author_email='habibutsu@gmail.com',
     maintainer='Alexander Verbitsky',

--- a/test.py
+++ b/test.py
@@ -77,6 +77,13 @@ class TestClient(unittest.TestCase):
         )
         assert response['code'] == 'Ok'
 
+        response = self.client.route(
+            coordinates=[[-74.0056, 40.6197], [-74.0034, 40.6333]],
+            overview=osrm.overview.full,
+            continue_straight=osrm.continue_straight.true
+        )
+        assert response['code'] == 'Ok'
+
     def test_match(self):
         response = self.client.match(
             coordinates=SAMPLE_ROUTE,

--- a/test.py
+++ b/test.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import json
 import logging
 import unittest
 from unittest.mock import MagicMock
@@ -10,9 +9,11 @@ import aiohttp
 import osrm
 
 logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger()
 
 OSRM_HOST = 'http://127.0.0.1:5000'
+SAMPLE_ROUTE = [[-74.005482, 40.679220], [-74.005389, 40.679495],
+                [-74.005014, 40.679746], [-74.004927, 40.679718],
+                [-74.004694, 40.679651]]
 
 
 class TestClient(unittest.TestCase):
@@ -28,7 +29,7 @@ class TestClient(unittest.TestCase):
             status_code=500,
             text='unexpected error')
         with self.assertRaises(osrm.OSRMServerException):
-            response = self.mock_client.nearest(
+            self.mock_client.nearest(
                 coordinates=[[-74.0056, 40.6197]],
                 number=10
             )
@@ -45,7 +46,7 @@ class TestClient(unittest.TestCase):
         response = self.client.nearest(
             coordinates=[[-74.00578245683002, 40.60600816104437]],
             radiuses=[70],
-            bearings=[[45,30]],
+            bearings=[[45, 30]],
             number=20
         )
         assert response['code'] == 'Ok'
@@ -58,7 +59,7 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.client.nearest(
                 coordinates=[[-74.00578245683002, 40.60600816104437]],
-                bearings=[[720,360]],
+                bearings=[[720, 360]],
             )
 
         with self.assertRaises(osrm.OSRMClientException) as cm:
@@ -78,11 +79,29 @@ class TestClient(unittest.TestCase):
 
     def test_match(self):
         response = self.client.match(
-            coordinates=[[-74.005482, 40.67922], [-74.005389, 40.679495], [-74.0050139317, 40.6797460083], [-74.004927, 40.679718], [-74.004694, 40.679651]],
+            coordinates=SAMPLE_ROUTE,
             radiuses=[9, 9, 10, 3, 3],
             overview=osrm.overview.full
         )
         assert response['code'] == 'Ok'
+
+        response = self.client.match(
+            coordinates=SAMPLE_ROUTE,
+            radiuses=[9, 9, 10, 3, 3],
+            timestamps=[10, 11, 1000, 1001, 1002],
+            gaps=osrm.gaps.split
+        )
+        assert response['code'] == 'Ok'
+        assert len(response['matchings']) == 2
+
+        response = self.client.match(
+            coordinates=SAMPLE_ROUTE,
+            radiuses=[9, 9, 10, 3, 3],
+            timestamps=[10, 11, 1000, 1001, 1002],
+            gaps=osrm.gaps.ignore
+        )
+        assert response['code'] == 'Ok'
+        assert len(response['matchings']) == 1
 
 
 def run_in_loop(f):
@@ -114,7 +133,6 @@ class TestAioHTTPClient(unittest.TestCase):
 
         self.loop.run_until_complete(_setUp())
 
-
     def tearDown(self):
         self.loop.run_until_complete(self.session.close())
         self.loop.close()
@@ -130,14 +148,13 @@ class TestAioHTTPClient(unittest.TestCase):
     @run_in_loop
     async def test_match(self):
         response = await self.client.match(
-            coordinates=[[-74.005482, 40.67922], [-74.005389, 40.679495], [-74.0050139317, 40.6797460083], [-74.004927, 40.679718], [-74.004694, 40.679651]],
+            coordinates=SAMPLE_ROUTE,
             radiuses=[9, 9, 10, 3, 3],
             overview=osrm.overview.full,
             tidy=False,
             gaps=osrm.gaps.split
         )
         assert response['code'] == 'Ok'
-
 
     @run_in_loop
     async def test_route(self):
@@ -150,6 +167,7 @@ class TestAioHTTPClient(unittest.TestCase):
     @run_in_loop
     async def test_retry(self):
         counter = 0
+
         def mock_get(url, **kwargs):
             nonlocal counter
             if counter < 2:
@@ -167,7 +185,7 @@ class TestAioHTTPClient(unittest.TestCase):
 
         self.mock_session.get = mock_get
 
-        response = await self.mock_client.nearest(
+        await self.mock_client.nearest(
             coordinates=[[-74.0056, 40.6197]], number=10
         )
         assert counter == 2
@@ -175,6 +193,7 @@ class TestAioHTTPClient(unittest.TestCase):
     @run_in_loop
     async def test_exceeded_max_retry(self):
         counter = 0
+
         def mock_get(url, **kwargs):
             nonlocal counter
             counter += 1
@@ -182,7 +201,7 @@ class TestAioHTTPClient(unittest.TestCase):
 
         self.mock_session.get = mock_get
         with self.assertRaises(osrm.OSRMServerException) as cm:
-            response = await self.mock_client.nearest(
+            await self.mock_client.nearest(
                 coordinates=[[-74.0056, 40.6197]], number=10
             )
         assert cm.exception.args[1] == 'server timeout'


### PR DESCRIPTION
Calling `client.match(gaps=osrm.gaps.ignore)` did not pass the parameter to OSRM.