### PR TITLE
Supporting MatchedRequests larger than OSRM 'max_match_size'

### DIFF
--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ import osrm
 
 logging.basicConfig(level=logging.DEBUG)
 
-OSRM_HOST = 'http://127.0.0.1:5000'
+OSRM_HOST = 'https://router.project-osrm.org'
 SAMPLE_ROUTE = [[-74.005482, 40.679220], [-74.005389, 40.679495],
                 [-74.005014, 40.679746], [-74.004927, 40.679718],
                 [-74.004694, 40.679651]]
@@ -41,7 +41,7 @@ class TestClient(unittest.TestCase):
             number=20
         )
         assert response['code'] == 'Ok'
-        assert len(response['waypoints']) == 12
+        assert len(response['waypoints']) == 14
 
         response = self.client.nearest(
             coordinates=[[-74.00578245683002, 40.60600816104437]],
@@ -50,7 +50,7 @@ class TestClient(unittest.TestCase):
             number=20
         )
         assert response['code'] == 'Ok'
-        assert len(response['waypoints']) == 3
+        assert len(response['waypoints']) == 4
 
         with self.assertRaises(AssertionError):
             self.client.nearest(
@@ -110,6 +110,19 @@ class TestClient(unittest.TestCase):
         assert response['code'] == 'Ok'
         assert len(response['matchings']) == 1
 
+    def test_match_sections(self):
+        responses = self.client.match_sections(
+            coordinates=SAMPLE_ROUTE,
+            radiuses=[9, 9, 10, 3, 3],
+            overview=osrm.overview.full,
+            max_match_size=3,
+            match_overlap=2/3
+        )
+
+        for sub_match in responses:
+            assert sub_match['code'] == 'Ok'
+
+
 
 def run_in_loop(f):
     @functools.wraps(f)
@@ -162,6 +175,19 @@ class TestAioHTTPClient(unittest.TestCase):
             gaps=osrm.gaps.split
         )
         assert response['code'] == 'Ok'
+
+    @run_in_loop
+    async def test_match_section(self):
+        responses = await self.client.match_sections(
+            coordinates=SAMPLE_ROUTE,
+            radiuses=[9, 9, 10, 3, 3],
+            overview=osrm.overview.full,
+            max_match_size=3,
+            match_overlap=2/3
+        )
+
+        for sub_match in responses:
+            assert sub_match['code'] == 'Ok'
 
     @run_in_loop
     async def test_route(self):


### PR DESCRIPTION
I utilized this simple module for a project of mine. However, I ran into the issue that I believe many other people face. The OSRM 'max_match_size' setting has a default value of 100. Therefore for longer sequences of points, I implemented a new request which properly sections and cuts a sequence of coordinates, radiuses, and timestamps, and submits them as a sequence of MatchRequests. However, I decided against post-processing these separate match requests and allowing the user to analyze them as needed.

- Moved helper functions outside of BaseRequest
- Implemented MatchRequestSections which iteratively calls MatchRequest
- Updated testcases with non-localhost OSRM server
- Added testcases for match_sections