### PR TITLE
fix (_encode_pairs): use dedicated float format

### DIFF
--- a/osrm.py
+++ b/osrm.py
@@ -133,7 +133,7 @@ class BaseRequest:
         return 'true' if value else 'false'
 
     def _encode_pairs(self, coordinates):
-        return ';'.join([','.join(map(str, coord)) for coord in coordinates])
+        return ';'.join([','.join(map('{.10f}.format', coord)) for coord in coordinates])
 
     def decode_response(self, url, status, response):
         if status == 200:


### PR DESCRIPTION
If just using function str(), it will not force float ot be written without scientific notation. Thus, it will not be accepted by OSRM API.

For example, coordinates '0.0000334622' translate to 3.34622E5 when printed using str, which is not accepted by OSRM